### PR TITLE
Improve Header and DashboardChart components

### DIFF
--- a/src/app/components/dashboard_chart.rs
+++ b/src/app/components/dashboard_chart.rs
@@ -3,17 +3,12 @@ use crate::app::models::Person;
 use charts_rs::{BarChart, Color, Series, THEME_DARK};
 use leptos::*;
 use num_format::{Buffer, Locale};
-use std::rc::Rc;
 
 #[component]
 pub fn DashboardChart(persons_data: Vec<Person>) -> impl IntoView {
-    //create a reference counting pointer to our actual persons data so
-    //Rust doesn't need to create/clone copies of the actual data every
-    //time
-    let retrieved_persons_data = Rc::new(persons_data.clone());
-
     // for counting the total number of team members
-    let team_count: String = retrieved_persons_data.len().to_string();
+    // we are using persons_data here only, so we can take ownership of it
+    let team_count: String = persons_data.len().to_string();
 
     // for calculating and adding the total cost for all the team members
     let mut total_cost: i32 = 0;

--- a/src/app/components/header.rs
+++ b/src/app/components/header.rs
@@ -28,10 +28,10 @@ pub fn Header() -> impl IntoView {
 
         <div class="flex mx-auto align-center items-center w-full h-12 pt-8 px-20 top-0 fixed">
             <nav class="flex flex-row w-full max-w-[52rem] h-12">
-                <div class={move || get_style_from_url(&current_path, "/")}>
+                <div class={move || get_style_from_url(current_path().as_str(), "/")}>
                     <A href="/">"Dashboard"</A>
                 </div>
-                <div class={move || get_style_from_url(&current_path, "/team")}>
+                <div class={move || get_style_from_url(current_path().as_str(), "/team")}>
                     <A href="/team">"Team"</A>
                 </div>
             </nav>
@@ -39,10 +39,10 @@ pub fn Header() -> impl IntoView {
     }
 }
 
-fn get_style_from_url<'a, 'b>(url: &'a ReadSignal<String>, match_url: &'a str) -> &'b str {
+fn get_style_from_url<'a>(url: &'a str, match_url: &'a str) -> &'static str {
     if url() == match_url {
-        return INPUT_STYLE_SELECTED;
+        INPUT_STYLE_SELECTED
+    } else {
+        INPUT_STYLE
     }
-
-    INPUT_STYLE
 }

--- a/src/app/components/header.rs
+++ b/src/app/components/header.rs
@@ -39,7 +39,7 @@ pub fn Header() -> impl IntoView {
     }
 }
 
-fn get_style_from_url<'a>(url: &'a str, match_url: &'a str) -> &'static str {
+fn get_style_from_url<'a, 'b>(url: &'a str, match_url: &'a str) -> &'b str {
     if url == match_url {
         INPUT_STYLE_SELECTED
     } else {

--- a/src/app/components/header.rs
+++ b/src/app/components/header.rs
@@ -40,7 +40,7 @@ pub fn Header() -> impl IntoView {
 }
 
 fn get_style_from_url<'a>(url: &'a str, match_url: &'a str) -> &'static str {
-    if url() == match_url {
+    if url == match_url {
         INPUT_STYLE_SELECTED
     } else {
         INPUT_STYLE


### PR DESCRIPTION
perf(dashboard_chart): take ownership of the passed in vector, since we only use it here, we don't need to borrow it by cloning, add explanatory comment
perf(header): simplify the `get_style_from_url` function by having only one lifetime, and having a string slice as input, instead of a reference to the `ReadSignal`